### PR TITLE
Fixes

### DIFF
--- a/lib/sassc/engine.rb
+++ b/lib/sassc/engine.rb
@@ -40,6 +40,8 @@ module SassC
 
       Native.delete_data_context(data_context)
 
+      css.force_encoding(@template.encoding)
+
       return css unless quiet?
     end
 

--- a/lib/sassc/native.rb
+++ b/lib/sassc/native.rb
@@ -49,7 +49,7 @@ module SassC
 
     def self.native_string(string)
       string += "\0"
-      data = Native::LibC.malloc(string.size)
+      data = Native::LibC.malloc(string.bytesize)
       data.write_string(string)
       data
     end


### PR DESCRIPTION
Two fixes:
* use `bytesize` when mallocing memory to handle multi-byte characters
* set the encoding of the output string to match input, in the past it would just force `ASCII_8BIT` since it was coming from FFI