### PR TITLE
Support Sass color custom function arguments

### DIFF
--- a/lib/sassc/error.rb
+++ b/lib/sassc/error.rb
@@ -1,3 +1,5 @@
+require 'sass/error'
+
 module SassC
   class SyntaxError < StandardError; end
   class NotRenderedError < StandardError; end

--- a/lib/sassc/functions_handler.rb
+++ b/lib/sassc/functions_handler.rb
@@ -30,6 +30,13 @@ module SassC
               argument = Script::String.new(Script::String.unquote(native_string), Script::String.type(native_string))
 
               custom_function_arguments << argument
+            when :sass_color
+              red, green, blue, alpha = Native.color_get_r(native_value), Native.color_get_g(native_value), Native.color_get_b(native_value), Native.color_get_a(native_value)
+
+              argument = Script::Color.new([red, green, blue, alpha])
+              argument.options = @options
+
+              custom_function_arguments << argument
             else
               error_tag = error("Sass argument of type #{value_tag} unsupported")
               break

--- a/lib/sassc/native/native_functions_api.rb
+++ b/lib/sassc/native/native_functions_api.rb
@@ -24,6 +24,19 @@ module SassC
     # ADDAPI const char* ADDCALL sass_string_get_value (const union Sass_Value* v);
     attach_function :sass_string_get_value, [:sass_value_ptr], :string
 
+    # ADDAPI double ADDCALL sass_color_get_r (const union Sass_Value* v);
+    # ADDAPI void ADDCALL sass_color_set_r (union Sass_Value* v, double r);
+    # ADDAPI double ADDCALL sass_color_get_g (const union Sass_Value* v);
+    # ADDAPI void ADDCALL sass_color_set_g (union Sass_Value* v, double g);
+    # ADDAPI double ADDCALL sass_color_get_b (const union Sass_Value* v);
+    # ADDAPI void ADDCALL sass_color_set_b (union Sass_Value* v, double b);
+    # ADDAPI double ADDCALL sass_color_get_a (const union Sass_Value* v);
+    # ADDAPI void ADDCALL sass_color_set_a (union Sass_Value* v, double a);
+    ['r', 'g', 'b', 'a'].each do |color_channel|
+      attach_function "sass_color_get_#{color_channel}".to_sym, [:sass_value_ptr], :double
+      attach_function "sass_color_set_#{color_channel}".to_sym, [:sass_value_ptr, :double], :void
+    end
+
     # ADDAPI size_t ADDCALL sass_list_get_length(const union Sass_Value* v)
     # ADDAPI union Sass_Value* ADDCALL sass_list_get_value (const union Sass_Value* v, size_t i);
     attach_function :sass_list_get_length, [:sass_value_ptr], :size_t

--- a/lib/sassc/script.rb
+++ b/lib/sassc/script.rb
@@ -18,3 +18,12 @@ end
 
 require_relative "script/functions"
 require_relative "script/string"
+
+module Sass
+  module Script
+  end
+end
+
+require 'sass/util'
+require 'sass/script/value/base'
+require_relative "script/color"

--- a/lib/sassc/script/color.rb
+++ b/lib/sassc/script/color.rb
@@ -1,0 +1,11 @@
+require 'sass/script/value/color'
+
+module SassC
+  module Script
+    class Color < ::Sass::Script::Value::Color
+      def to_native
+        Native::make_string(to_s)
+      end
+    end
+  end
+end

--- a/sassc.gemspec
+++ b/sassc.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "bundler"
   spec.add_dependency "ffi", "~> 1.9.6"
-  spec.add_dependency "sass"
+  spec.add_dependency "sass", "~> 3.4.15"
 
   gem_dir = File.expand_path(File.dirname(__FILE__)) + "/"
   `git submodule --quiet foreach pwd`.split($\).each do |submodule_path|

--- a/sassc.gemspec
+++ b/sassc.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "bundler"
   spec.add_dependency "ffi", "~> 1.9.6"
+  spec.add_dependency "sass"
 
   gem_dir = File.expand_path(File.dirname(__FILE__)) + "/"
   `git submodule --quiet foreach pwd`.split($\).each do |submodule_path|

--- a/test/functions_test.rb
+++ b/test/functions_test.rb
@@ -62,16 +62,24 @@ div {
       EOS
     end
 
+    def test_functions_may_accept_sass_color_type
+      engine = Engine.new("div { color: nice_color_argument(red); }")
+      assert_equal <<-EOS, engine.render
+div {
+  color: "red"; }
+      EOS
+    end
+
     def test_function_with_unsupported_tag
-      engine = Engine.new("div {url: function_with_unsupported_tag(red);}")
+      engine = Engine.new("div {url: function_with_unsupported_tag(1);}")
 
       exception = assert_raises(SassC::SyntaxError) do
         engine.render
       end
 
-      assert_equal "Error: error in C function function_with_unsupported_tag: Sass argument of type sass_color unsupported\n\n       Backtrace:\n       \tstdin:1, in function `function_with_unsupported_tag`\n       \tstdin:1\n        on line 1 of stdin\n>> div {url: function_with_unsupported_tag(red);}\n   ----------^\n", exception.message
+      assert_equal "Error: error in C function function_with_unsupported_tag: Sass argument of type sass_number unsupported\n\n       Backtrace:\n       \tstdin:1, in function `function_with_unsupported_tag`\n       \tstdin:1\n        on line 1 of stdin\n>> div {url: function_with_unsupported_tag(1);}\n   ----------^\n", exception.message
 
-      assert_equal "[SassC::FunctionsHandler] Sass argument of type sass_color unsupported", stderr_output
+      assert_equal "[SassC::FunctionsHandler] Sass argument of type sass_number unsupported", stderr_output
     end
 
     def test_function_with_error
@@ -122,7 +130,11 @@ div {
         raise StandardError, "Intentional wrong thing happened somewhere inside the custom function"
       end
 
-      def function_with_unsupported_tag(color)
+      def function_with_unsupported_tag(number)
+      end
+
+      def nice_color_argument(color)
+        return Script::String.new(color.to_s, :string)
       end
 
       module Compass


### PR DESCRIPTION
Adds support for `:sass_color`

Also brings in Sass dependency to ride `Script::Color` off of 

(*sad but probably the best way trombone*)

For review: @bolandrm @nickjs 