### PR TITLE
Extracts #to_native out of types

### DIFF
--- a/lib/sassc/script/color.rb
+++ b/lib/sassc/script/color.rb
@@ -2,10 +2,14 @@ require 'sass/script/value/color'
 
 module SassC
   module Script
-    class Color < ::Sass::Script::Value::Color
+    module NativeColor
       def to_native
         Native::make_color(red, green, blue, alpha)
       end
+    end
+
+    class Color < ::Sass::Script::Value::Color
+      include NativeColor
     end
   end
 end

--- a/lib/sassc/script/string.rb
+++ b/lib/sassc/script/string.rb
@@ -2,7 +2,7 @@ require 'sass/script/value/string'
 
 module SassC
   module Script
-    class String < ::Sass::Script::Value::String
+    module NativeString
       def to_native(opts = {})
         if opts[:quote] == :none || type == :identifier
           Native::make_string(to_s)
@@ -10,6 +10,10 @@ module SassC
           Native::make_qstring(to_s)
         end
       end
+    end
+
+    class String < ::Sass::Script::Value::String
+      include NativeString
     end
   end
 end


### PR DESCRIPTION
Part of a fix for https://github.com/bolandrm/sassc-rails/issues/30

This makes it easier for sassc-rails to mix in the `#to_native` functionality provided by sassc-ruby into Sass types. We need this because sassc-rails registers `Sprockets::SassFunctions` with sassc-ruby except that those functions are hardcoded to return Sass types that don’t have `#to_native` defined on them.